### PR TITLE
Upgrade rest-client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,11 +8,20 @@ GEM
       term-ansicolor
       thor
     diff-lcs (1.2.5)
-    mime-types (2.1)
+    domain_name (0.5.20161129)
+      unf (>= 0.0.5, < 1.0.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     multi_json (1.8.2)
+    netrc (0.11.0)
     rake (10.1.1)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rest-client (2.0.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -29,6 +38,9 @@ GEM
       tins (~> 0.8)
     thor (0.18.1)
     tins (0.12.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
 
 PLATFORMS
   ruby
@@ -38,3 +50,6 @@ DEPENDENCIES
   rake
   rspec
   rspec-core
+
+BUNDLED WITH
+   1.13.7

--- a/writeit-rails.gemspec
+++ b/writeit-rails.gemspec
@@ -9,5 +9,5 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split("\n")
   s.homepage    = 'http://rubygems.org/gems/writeit-rails'
   s.license       = 'Apache License, Version 2.0'
-  s.add_runtime_dependency 'rest-client', '1.6.7'
+  s.add_runtime_dependency 'rest-client', '>= 1.6.7'
 end


### PR DESCRIPTION
Fix

Name: rest-client
Version: 1.6.7
Advisory: CVE-2015-3448
Criticality: Unknown
URL: http://www.osvdb.org/show/osvdb/117461
Title: Rest-Client Gem for Ruby logs password information in plaintext
Solution: upgrade to >= 1.7.3

Name: rest-client
Version: 1.6.7
Advisory: CVE-2015-1820
Criticality: Unknown
URL: https://github.com/rest-client/rest-client/issues/369
Title: rubygem-rest-client: session fixation vulnerability via Set-Cookie headers in 30x redirection responses
Solution: upgrade to >= 1.8.0